### PR TITLE
Fix typo for getSortedSpecificity function

### DIFF
--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -67,7 +67,7 @@ module.exports = function (root, opts) {
   }
 
   if (opts.sortedSpecificityGraph) {
-    result.specificity.sortedGraph = result.getSortedSpecificityGraph()
+    result.specificity.sortedGraph = result.getSortedSpecificity()
   }
 
   if (opts.repeatedSelectors) {


### PR DESCRIPTION
I didn't want to chagne much so I did the minimal change possible without affecting the API, but now the option is `sortedSpecificityGraph` and the function is `getSortedSpecificity` not a biggie but might be confusing.