### PR TITLE
Ensure that all selectors are not blank

### DIFF
--- a/lib/get-specificity-graph.js
+++ b/lib/get-specificity-graph.js
@@ -1,15 +1,17 @@
 
+var isBlank = require('is-blank')
+var isPresent = require('is-present')
 var specificity = require('specificity')
 
 module.exports = function (selectors) {
 
   selectors = selectors || this.values
 
-  if (!selectors) {
+  if (isBlank(selectors)) {
     return false
   }
 
-  return selectors.map(graph)
+  return selectors.filter(isPresent).map(graph)
 
   function graph (selector) {
     return specificity.calculate(selector)[0]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "has-id-selector": "1.0.0",
     "has-pseudo-class": "0.0.1",
     "has-pseudo-element": "1.0.0",
+    "is-blank": "^1.1.0",
+    "is-present": "^1.0.0",
     "is-vendor-prefixed": "0.0.1",
     "lodash": "^3.0.0",
     "postcss": "^5.0.0",


### PR DESCRIPTION
This can happen with a malformed selector like

```css
.foo,
.bar, {
  color: tomato;
}
```