### PR TITLE
Update lodash dependency to minimal viable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "is-blank": "^1.1.0",
     "is-present": "^1.0.0",
     "is-vendor-prefixed": "0.0.1",
-    "lodash": "^3.0.0",
+    "lodash": "^3.4.0",
     "postcss": "^5.0.0",
     "postcss-safe-parser": "^1.0.0",
     "specificity": "^0.1.4",


### PR DESCRIPTION
The current lodash version range can result in a version of lodash that is incompatible with this library.
An example of is `_.sum` which was introduced in [lodash@3.4.0](https://github.com/lodash/lodash/wiki/Changelog#v340).